### PR TITLE
Support macOS builds

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -21,7 +21,7 @@ jobs:
       extension_name: mlpack
       # mingw fails, as does wasm_eh, and osx runs into a patchable cereal issue
       #exclude_archs: "windows_amd64_mingw;windows_amd64;osx_amd64;osx_arm64;wasm_mvp;wasm_eh;wasm_threads"
-      exclude_archs: "windows;wasm;linux"
+      exclude_archs: "linux_amd64;linux_arm64;linux_amd64_musl;windows_amd64_mingw;windows_amd64;wasm_mvp;wasm_eh;wasm_threads"
       # add fortran and omp for armadillo below mlpack
       extra_toolchains: "fortran;omp"    
 

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -3,7 +3,7 @@
 #
 name: Main Extension Distribution Pipeline
 on:
-  push:
+  #push:
   #pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -20,8 +20,9 @@ jobs:
       ci_tools_version: v1.4.1
       extension_name: mlpack
       # mingw fails, as does wasm_eh, and osx runs into a patchable cereal issue
-      #exclude_archs: "windows_amd64_mingw;windows_amd64;osx_amd64;osx_arm64;wasm_mvp;wasm_eh;wasm_threads"
-      exclude_archs: "linux_amd64;linux_arm64;linux_amd64_musl;windows_amd64_mingw;windows_amd64;wasm_mvp;wasm_eh;wasm_threads"
+      exclude_archs: "windows_amd64_mingw;windows_amd64;wasm_mvp;wasm_eh;wasm_threads"
+      # to test macOS only, try e.g.
+      #exclude_archs: "linux_amd64;linux_arm64;linux_amd64_musl;windows_amd64_mingw;windows_amd64;wasm_mvp;wasm_eh;wasm_threads"
       # add fortran and omp for armadillo below mlpack
       extra_toolchains: "fortran;omp"    
 

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -3,7 +3,7 @@
 #
 name: Main Extension Distribution Pipeline
 on:
-  #push:
+  push:
   #pull_request:
   workflow_dispatch:
 
@@ -20,7 +20,8 @@ jobs:
       ci_tools_version: v1.4.1
       extension_name: mlpack
       # mingw fails, as does wasm_eh, and osx runs into a patchable cereal issue
-      exclude_archs: "windows_amd64_mingw;windows_amd64;osx_amd64;osx_arm64;wasm_mvp;wasm_eh;wasm_threads"
+      #exclude_archs: "windows_amd64_mingw;windows_amd64;osx_amd64;osx_arm64;wasm_mvp;wasm_eh;wasm_threads"
+      exclude_archs: "windows;wasm;linux"
       # add fortran and omp for armadillo below mlpack
       extra_toolchains: "fortran;omp"    
 

--- a/CMake/mlpack.cmake
+++ b/CMake/mlpack.cmake
@@ -402,6 +402,13 @@ macro(find_cereal)
       string(REGEX REPLACE ".*#define CEREAL_VERSION_PATCH ([0-9]+).*" "\\1"
           CEREAL_VERSION_PATCH "${_CEREAL_HEADER_CONTENTS}")
 
+      file(READ ${CEREAL_INCLUDE_DIR}/cereal/types/tuple.hpp CEREAL_TUPLE)
+      string(REPLACE
+          "::template apply" "::apply"
+          CEREAL_TUPLE "${CEREAL_TUPLE}")
+      file(WRITE ${CEREAL_INCLUDE_DIR}/cereal/types/tuple.hpp "${CEREAL_TUPLE}")
+      message(STATUS "${CEREAL_TUPLE}")
+
     elseif (EXISTS "${CEREAL_INCLUDE_DIR}/cereal/details/polymorphic_impl_fwd.hpp")
 
       set(CEREAL_VERSION_MAJOR 1)
@@ -414,12 +421,12 @@ macro(find_cereal)
       set(CEREAL_VERSION_PATCH 2)
     elseif (EXISTS "${CEREAL_INCLUDE_DIR}/cereal/cereal.hpp")
 
-    set(CEREAL_VERSION_MAJOR 1)
-    set(CEREAL_VERSION_MINOR 1)
-    set(CEREAL_VERSION_PATCH 1)
-  else()
+      set(CEREAL_VERSION_MAJOR 1)
+      set(CEREAL_VERSION_MINOR 1)
+      set(CEREAL_VERSION_PATCH 1)
+    else()
 
-    set(CEREAL_FOUND NO)
+      set(CEREAL_FOUND NO)
     endif()
     set(CEREAL_VERSION_STRING "${CEREAL_VERSION_MAJOR}.${CEREAL_VERSION_MINOR}.${CEREAL_VERSION_PATCH}")
   endif ()

--- a/CMake/mlpack.cmake
+++ b/CMake/mlpack.cmake
@@ -407,7 +407,8 @@ macro(find_cereal)
           "::template apply" "::apply"
           CEREAL_TUPLE "${CEREAL_TUPLE}")
       file(WRITE ${CEREAL_INCLUDE_DIR}/cereal/types/tuple.hpp "${CEREAL_TUPLE}")
-      message(STATUS "${CEREAL_TUPLE}")
+      #message(STATUS "${CEREAL_TUPLE}")
+      message(STATUS "Patched cereal include file 'tuple.hpp'")
 
     elseif (EXISTS "${CEREAL_INCLUDE_DIR}/cereal/details/polymorphic_impl_fwd.hpp")
 

--- a/src/mlpack_adaboost.cpp
+++ b/src/mlpack_adaboost.cpp
@@ -42,7 +42,8 @@ void MlpackAdaboostTableFunction(ClientContext &context, TableFunctionInput &dat
 	if (verbose)
 		dataset.print("dataset");
 	// Dependent variable i.e. 'labels'
-	arma::Row<size_t> labelsvec = get_armadillo_row<size_t>(context, resdata.labels);
+	arma::Row<double> labelsvecdbl = get_armadillo_row<double>(context, resdata.labels);
+	arma::Row<size_t> labelsvec = arma::conv_to<arma::Row<size_t>>::from(labelsvecdbl);
 	if (arma::min(labelsvec) != 0)
 		labelsvec = labelsvec - 1;
 	if (verbose)


### PR DESCRIPTION
This mostly involved finding the right spot for the one-line-twice patch to the `cereal` file, as well as for unclear reasons avoid reading a file of integer values as `size_t` and converting later.

/cc @rcurtin 