### PR TITLE
Expand model table to serialize linear regression coefficients

### DIFF
--- a/sampleCall.sh
+++ b/sampleCall.sh
@@ -23,7 +23,7 @@ CREATE TABLE X AS SELECT * FROM read_csv("https://eddelbuettel.github.io/duckdb-
 CREATE TABLE Y AS SELECT * FROM read_csv("https://eddelbuettel.github.io/duckdb-mlpack/data/iris_labels.csv");
 CREATE TABLE Z (name VARCHAR, value VARCHAR);
 INSERT INTO Z VALUES ('iterations', '50'), ('tolerance', '1e-7'), ('verbose', 'true');
-CREATE TABLE M (json VARCHAR);
+CREATE TABLE M (key VARCHAR, json VARCHAR);
 
 -- train model off 'X' to predict 'Y' using (non-default) parameters in 'Z'
 -- serialize model (in JSON) to table 'M'
@@ -50,28 +50,22 @@ CREATE TABLE X AS SELECT * FROM read_csv("https://eddelbuettel.github.io/duckdb-
 CREATE TABLE Y AS SELECT * FROM read_csv("https://eddelbuettel.github.io/duckdb-mlpack/data/trees_y.csv");
 CREATE TABLE Z (name VARCHAR, value VARCHAR);
 INSERT INTO Z VALUES ('intercept', 'true');
-CREATE TABLE M (json VARCHAR);
+CREATE TABLE M (key VARCHAR, json VARCHAR);
 
-CREATE TABLE A AS SELECT * FROM mlpack_linear_regression_fit("X", "Y", "Z", "M");
+SELECT * FROM mlpack_linear_regression_fit("X", "Y", "Z", "M");
 
-## Checks
-SELECT * FROM A;
-#SELECT * FROM M;
-
-## For simplicity re-fit from given data
-#SELECT * FROM (SELECT * FROM mlpack_linear_regression_pred("X", "M"));
+SELECT * FROM M WHERE key = 'coefficients';
 
 ## Create a quick new data table with arbitrary values and compute prediction on new data
-## This replicates what we
-#CREATE TABLE N (x1 DOUBLE, x2 DOUBLE);
-#INSERT INTO N VALUES ('1', '1'), ('2', '-1'), ('3', '1');
-#SELECT * FROM (SELECT * FROM mlpack_linear_regression_pred("N", "M"));
+## This replicates what we see in R with these values
+CREATE TABLE N (x1 DOUBLE, x2 DOUBLE);
+INSERT INTO N VALUES ('1', '1'), ('2', '-1'), ('3', '1');
+SELECT * FROM mlpack_linear_regression_pred("N", "M");
 
-#DROP TABLE X;
-#DROP TABLE Y;
-#DROP TABLE Z;
-#DROP TABLE A;
-#DROP TABLE M;
+DROP TABLE X;
+DROP TABLE Y;
+DROP TABLE Z;
+DROP TABLE M;
 
 EOF
 }
@@ -84,10 +78,10 @@ CREATE TABLE X AS SELECT * FROM read_csv("https://eddelbuettel.github.io/duckdb-
 CREATE TABLE Y AS SELECT * FROM read_csv("https://eddelbuettel.github.io/duckdb-mlpack/data//covertype_small_labels.csv.gz");
 CREATE TABLE Z (name VARCHAR, value VARCHAR);
 INSERT INTO Z VALUES ('intercept', 'false'), ('lambda', '0.05');
-CREATE TABLE M (json VARCHAR);
+CREATE TABLE M (key VARCHAR, json VARCHAR);
 
 CREATE TEMP TABLE A AS SELECT * FROM mlpack_linear_regression_fit("X", "Y", "Z", "M");
-SELECT * FROM M;
+SELECT * FROM M WHERE key = 'coefficients';
 
 EOF
 }

--- a/src/duckdb_utilities.cpp
+++ b/src/duckdb_utilities.cpp
@@ -28,13 +28,13 @@ std::map<std::string, std::string> get_parameters(ClientContext &context, std::s
 
 void store_model(ClientContext &context, std::string model_table, std::string model_as_json) {
 	Connection con(*context.db);
-	std::string query = std::string("INSERT INTO " + model_table + " VALUES ('" + model_as_json + "');");
+	std::string query = std::string("INSERT INTO " + model_table + " VALUES ('model', '" + model_as_json + "');");
 	con.Query(query);
 }
 
 std::string retrieve_model(ClientContext &context, std::string model_table) {
 	Connection con(*context.db);
-	std::string query = std::string("SELECT * FROM " + model_table + ";");
+	std::string query = std::string("SELECT json FROM " + model_table + " WHERE key = 'model';");
 	auto result = con.Query(query);
 	idx_t n = result->RowCount(), k = result->ColumnCount();
 	assert(n == 1);
@@ -43,6 +43,23 @@ std::string retrieve_model(ClientContext &context, std::string model_table) {
 	std::string mod = result->GetValue(0, 0).GetValue<std::string>();
 	// std::cout << "Model: " << mod << std::endl;
 	return mod;
+}
+
+// mlpack can serialize models but not arma vectors
+std::string serialize_vector(const arma::vec &vec) {
+	std::vector<double> parameters {vec.memptr(), vec.memptr() + vec.n_elem};
+	std::ostringstream oss;
+	{ // need a block to have 'o' destructed for final closing '}'
+		cereal::JSONOutputArchive o(oss);
+		o(CEREAL_NVP(parameters));
+	}
+	return oss.str();
+}
+
+void store_vector(ClientContext &context, std::string model_table, std::string key, std::string model_as_json) {
+	Connection con(*context.db);
+	std::string query = std::string("INSERT INTO " + model_table + " VALUES ('" + key + "', '" + model_as_json + "');");
+	con.Query(query);
 }
 
 } // namespace duckdb

--- a/src/include/duckdb_utilities.hpp
+++ b/src/include/duckdb_utilities.hpp
@@ -12,6 +12,8 @@ namespace duckdb {
 std::map<std::string, std::string> get_parameters(ClientContext &context, std::string parameters);
 void store_model(ClientContext &context, std::string model_table, std::string model_as_json);
 std::string retrieve_model(ClientContext &context, std::string model_table);
+std::string serialize_vector(const arma::vec &vec);
+void store_vector(ClientContext &context, std::string model_table, std::string key, std::string model_as_json);
 
 template <typename T>
 arma::Mat<T> get_armadillo_matrix_transposed(ClientContext &context, std::string &table) {

--- a/src/mlpack_adaboost.cpp
+++ b/src/mlpack_adaboost.cpp
@@ -58,7 +58,6 @@ void MlpackAdaboostTableFunction(ClientContext &context, TableFunctionInput &dat
 	const int perceptronIter = params.count("perceptronIter") > 0 ? std::stoi(params["perceptronIter"]) : 400;
 	const bool silent = params.count("silent") > 0 ? (params["silent"] == "true" ? true : false) : false;
 
-
 	double ztProduct = a.Train(dataset, labelsvec, numClasses, iterations, tolerance, perceptronIter);
 
 	if (verbose)

--- a/src/mlpack_linear_regression.cpp
+++ b/src/mlpack_linear_regression.cpp
@@ -51,6 +51,11 @@ void MlpackLinRegTableFunction(ClientContext &context, TableFunctionInput &data_
 		std::cout << SerializeObject<mlpack::LinearRegression<>>(lr) << std::endl;
 	store_model(context, resdata.model, SerializeObject<mlpack::LinearRegression<>>(lr));
 
+	auto avec = lr.Parameters();
+	if (verbose)
+		std::cout << "Coefficients:" << serialize_vector(avec) << std::endl;
+	store_vector(context, resdata.model, "coefficients", serialize_vector(avec));
+
 	auto n = labelsvec.n_elem;
 	arma::rowvec fittedvalues(n);
 	lr.Predict(dataset, fittedvalues);

--- a/test/sql/mlpack.test
+++ b/test/sql/mlpack.test
@@ -44,10 +44,10 @@ statement ok
 CREATE TABLE Z (name VARCHAR, value VARCHAR);
 
 statement ok
-INSERT INTO Z VALUES ('iterations', '50'), ('tolerance', '1e-7'), ('verbose', 'false');
+INSERT INTO Z VALUES ('iterations', '50'), ('tolerance', '1e-7'), ('silent', 'true');
 
 statement ok
-CREATE TABLE M (json VARCHAR);
+CREATE TABLE M (key VARCHAR, json VARCHAR);
 
 statement ok
 CREATE TEMP TABLE A AS SELECT * FROM mlpack_adaboost_train("X", "Y", "Z", "M");
@@ -68,9 +68,17 @@ INSERT INTO N VALUES (5.843, 3.054, 3.759, 1.199), (4.3, 2.0, 1.0, 0.1), (7.9, 4
 statement ok
 CREATE TEMP TABLE B AS SELECT * FROM mlpack_adaboost_pred("N", "M");
 
+query I
+SELECT * FROM B;
+----
+1
+0
+2
+
 query II
 SELECT COUNT(*) as n, predicted FROM B GROUP BY predicted;
 ----
 1	0
 1	1
 1	2
+


### PR DESCRIPTION
This PR makes the 'model' output table two-columns so that for example coefficients from linear_regression can be stored.  It is less clear what use this would have for boosting models or tree models with many parameters.  Also, coefficients are already part of the model output so maybe a SQL function unwrapping the JSON is all we need?

Any thoughts, @rcurtin ?